### PR TITLE
Add AMD GPU scheduling support

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -951,8 +951,14 @@ static resrc_t *resrc_new_from_hwloc_obj (resrc_api_ctx_t *ctx, hwloc_obj_t obj,
          */
         if (strncmp(obj->name, "cuda", 4) == 0)
             id = atoi (obj->name + 4);
-        else if (strncmp(obj->name, "opencl", 6) == 0)
-            id = atoi (obj->name + 6);
+        else if (strncmp(obj->name, "opencl", 6) == 0) {
+            /* Naming convention of opencl devices for hwloc:
+            * "opencl" followed by a platform ID followed by a device ID.
+            * Then, the letter d delimits platform id and device id.
+            */
+            const char *delim = strchr (obj->name + 6, 'd');
+            id = atoi (delim + 1);
+        }
         type = xstrdup ("gpu");
         name = xasprintf ("%s%"PRId64"", type, id);
     } else {

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-corona/0.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-corona/0.xml
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-957.10.1.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Thu Mar 14 17:57:30 PDT 2019"/>
+    <info name="HostName" value="corona11"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.12"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="34243170304">
+        <page_type size="4096" count="8360149"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <info name="PCISlot" value="1"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM00001E2F9"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8a"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8b"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:13:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="controlD65" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d0" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:23:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                  <object type="OSDev" name="controlD66" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d1" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="0.000000">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:00:86:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9b:54"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x11"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9b54"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:53:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                  <object type="OSDev" name="controlD67" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d2" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:73:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="controlD68" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d3" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-corona/1.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-corona/1.xml
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-957.10.1.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Thu Mar 14 17:57:30 PDT 2019"/>
+    <info name="HostName" value="corona12"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.12"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="34243170304">
+        <page_type size="4096" count="8360149"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <info name="PCISlot" value="1"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM00001E2F9"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8a"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8b"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:13:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="controlD65" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d0" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:23:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                  <object type="OSDev" name="controlD66" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d1" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="0.000000">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:00:86:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9b:54"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x11"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9b54"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:53:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                  <object type="OSDev" name="controlD67" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d2" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:73:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="controlD68" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d3" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-corona/2.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-corona/2.xml
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-957.10.1.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Thu Mar 14 17:57:30 PDT 2019"/>
+    <info name="HostName" value="corona13"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.12"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="34243170304">
+        <page_type size="4096" count="8360149"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <info name="PCISlot" value="1"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM00001E2F9"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8a"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8b"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:13:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="controlD65" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d0" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:23:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                  <object type="OSDev" name="controlD66" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d1" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="0.000000">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:00:86:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9b:54"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x11"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9b54"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:53:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                  <object type="OSDev" name="controlD67" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d2" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:73:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="controlD68" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d3" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/t/data/hwloc-data/004N/exclusive/04-brokers-corona/3.xml
+++ b/t/data/hwloc-data/004N/exclusive/04-brokers-corona/3.xml
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-957.10.1.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Thu Mar 14 17:57:30 PDT 2019"/>
+    <info name="HostName" value="corona14"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.12"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="34243170304">
+        <page_type size="4096" count="8360149"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <info name="PCISlot" value="1"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM00001E2F9"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8a"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:ae:8b"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:13:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="controlD65" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d0" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:23:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                  <object type="OSDev" name="controlD66" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d1" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="0.000000">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:00:86:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9b:54"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9b54"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x11"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9b54"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:53:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                  <object type="OSDev" name="controlD67" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d2" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="34359214080">
+        <page_type size="4096" count="8388480"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1022:1470] [0000:0000] 01" pci_link_speed="0.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1022:1471] [0000:0000] 00" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 [Radeon Instinct MI25]" pci_busid="0000:73:00.0" pci_type="0300 [1002:6860] [1002:0c35] 01" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 10 [Radeon Instinct MI25]"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="controlD68" osdev_type="1"/>
+                  <object type="OSDev" name="opencl0d3" osdev_type="5">
+                    <info name="CoProcType" value="OpenCL"/>
+                    <info name="Backend" value="OpenCL"/>
+                    <info name="OpenCLDeviceType" value="GPU"/>
+                    <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
+                    <info name="GPUModel" value="Vega 10 [Radeon Instinct MI25]"/>
+                    <info name="OpenCLPlatformIndex" value="0"/>
+                    <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
+                    <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                    <info name="OpenCLComputeUnits" value="64"/>
+                    <info name="OpenCLGlobalMemorySize" value="16760832"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>


### PR DESCRIPTION
This PR is the backport of AMD GPU support for the old scheduler. The PR for the graph based schedule is posted at https://github.com/flux-framework/flux-sched/pull/464.